### PR TITLE
Resolve documentation issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ Subscribe to RHSM using username and password and attach to a pool
        - rh-gluster-3-nfs-for-rhel-7-server-rpms
        - rhel-ha-for-rhel-7-server-rpms
   roles:
-    - gluster.repos
+    - gluster.repositories
 ```


### PR DESCRIPTION
The roles section of the README is pointing at gluster.repos when it's more likely that the role name would match the git repository name (repositories).