### PR TITLE
Update main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
     msg: "Password is needed when activation key is not given"
   when:
     - gluster_repos_password is not defined
-    - gluster_repos_activationkey not is defined
+    - gluster_repos_activationkey is not defined
 
 - name: Register with activation key, if activation key is provided
   redhat_subscription:


### PR DESCRIPTION
As a part of this issue:- https://github.com/gluster/gluster-ansible-repositories/issues/7

Possible fix for :- 
The error was: template error while templating string: expected token 'end of statement block', got 'not'. String: {% if gluster_repos_activationkey not is defined %}